### PR TITLE
Add imread

### DIFF
--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     try:
         from skimage.external import tifffile
-    except ImportError:
+    except ImportError:  # pragma: no cover
         pass
 
 

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -9,6 +9,10 @@ __version__ = get_versions()['version']
 del get_versions
 
 
+import itertools
+import numbers
+import warnings
+
 import dask
 import dask.array
 import dask.delayed
@@ -21,23 +25,53 @@ try:
 except NameError:
     irange = range
 
+try:
+    izip = itertools.izip
+except AttributeError:
+    izip = zip
 
-def imread(fn):
+
+def imread(fn, nframes=1):
+    if not isinstance(nframes, numbers.Integral):
+        raise ValueError("`nframes` must be an integer.")
+    if not (nframes > 0):
+        raise ValueError("`nframes` must be greater than zero.")
+
     with pims.open(fn) as imgs:
         shape = (len(imgs),) + imgs.frame_shape
         dtype = numpy.dtype(imgs.pixel_type)
 
+    if nframes > shape[0]:
+        warnings.warn(
+            "`nframes` larger than number of frames in file."
+            " Will truncate to number of frames in file.",
+            RuntimeWarning
+        )
+    elif shape[0] % nframes != 0:
+        warnings.warn(
+            "`nframes` does not nicely divide number of frames in file."
+            " Last chunk will contain the remainder.",
+            RuntimeWarning
+        )
+
     def _read_frame(fn, i):
         with pims.open(fn) as imgs:
-            return imgs[i]
+            return numpy.asanyarray(imgs[i])
+
+    lower_iter, upper_iter = itertools.tee(itertools.chain(
+        irange(0, shape[0], nframes),
+        [shape[0]]
+    ))
+
+    next(upper_iter)
 
     a = []
-    for i in irange(shape[0]):
+    for i, j in izip(lower_iter, upper_iter):
         a.append(dask.array.from_delayed(
-            dask.delayed(_read_frame)(fn, i),
-            shape[1:],
+            dask.delayed(_read_frame)(fn, slice(i, j)),
+            (j - i,) + shape[1:],
             dtype
         ))
-    a = dask.array.stack(a)
+    a = dask.array.concatenate(a)
 
     return a

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -35,6 +35,25 @@ if pims.tiff_stack.tifffile is None:
 
 
 def imread(fname, nframes=1):
+    """
+    Read image data into a Dask Array.
+
+    Provides a simple, fast mechanism to ingest image data into a
+    Dask Array.
+
+    Parameters
+    ----------
+    fname : str
+        A glob like string that may match one or multiple filenames.
+    nframes : int, optional
+        Number of the frames to include in each chunk (default: 1).
+
+    Returns
+    -------
+    array : dask.array.Array
+        A Dask Array representing the contents of all image files.
+    """
+
     try:
         irange = xrange
     except NameError:

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -29,6 +29,11 @@ except ImportError:
         pass
 
 
+# Monkey patch pims to use the available tifffile.
+if pims.tiff_stack.tifffile is None:
+    pims.tiff_stack.tifffile = tifffile
+
+
 def imread(fn, nframes=1):
     try:
         irange = xrange

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -19,6 +19,15 @@ import dask.delayed
 import numpy
 import pims
 
+tifffile = None
+try:
+    import tifffile
+except ImportError:
+    try:
+        from skimage.external import tifffile
+    except ImportError:
+        pass
+
 
 def imread(fn, nframes=1):
     try:

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -20,18 +20,17 @@ import numpy
 import pims
 
 
-try:
-    irange = xrange
-except NameError:
-    irange = range
-
-try:
-    izip = itertools.izip
-except AttributeError:
-    izip = zip
-
-
 def imread(fn, nframes=1):
+    try:
+        irange = xrange
+    except NameError:
+        irange = range
+
+    try:
+        izip = itertools.izip
+    except AttributeError:
+        izip = zip
+
     if not isinstance(nframes, numbers.Integral):
         raise ValueError("`nframes` must be an integer.")
     if not (nframes > 0):

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -61,7 +61,6 @@ def imread(fn, nframes=1):
         irange(0, shape[0], nframes),
         [shape[0]]
     ))
-
     next(upper_iter)
 
     a = []

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -16,6 +16,12 @@ import numpy
 import pims
 
 
+try:
+    irange = xrange
+except NameError:
+    irange = range
+
+
 def imread(fn):
     with pims.open(fn) as imgs:
         shape = (len(imgs),) + imgs.frame_shape
@@ -26,7 +32,7 @@ def imread(fn):
             return imgs[i]
 
     a = []
-    for i in range(shape[0]):
+    for i in irange(shape[0]):
         a.append(dask.array.from_delayed(
             dask.delayed(_read_frame)(fn, i),
             shape[1:],

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -1,8 +1,37 @@
 # -*- coding: utf-8 -*-
 
+
 __author__ = """John Kirkham"""
 __email__ = "kirkhamj@janelia.hhmi.org"
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+import dask
+import dask.array
+import dask.delayed
+import numpy
+import pims
+
+
+def imread(fn):
+    with pims.open(fn) as imgs:
+        shape = (len(imgs),) + imgs.frame_shape
+        dtype = numpy.dtype(imgs.pixel_type)
+
+    def _read_frame(fn, i):
+        with pims.open(fn) as imgs:
+            return imgs[i]
+
+    a = []
+    for i in range(shape[0]):
+        a.append(dask.array.from_delayed(
+            dask.delayed(_read_frame)(fn, i),
+            shape[1:],
+            dtype
+        ))
+    a = dask.array.stack(a)
+
+    return a

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -34,7 +34,7 @@ if pims.tiff_stack.tifffile is None:
     pims.tiff_stack.tifffile = tifffile
 
 
-def imread(fn, nframes=1):
+def imread(fname, nframes=1):
     try:
         irange = xrange
     except NameError:
@@ -50,7 +50,7 @@ def imread(fn, nframes=1):
     if not (nframes > 0):
         raise ValueError("`nframes` must be greater than zero.")
 
-    with pims.open(fn) as imgs:
+    with pims.open(fname) as imgs:
         shape = (len(imgs),) + imgs.frame_shape
         dtype = numpy.dtype(imgs.pixel_type)
 
@@ -80,7 +80,7 @@ def imread(fn, nframes=1):
     a = []
     for i, j in izip(lower_iter, upper_iter):
         a.append(dask.array.from_delayed(
-            dask.delayed(_read_frame)(fn, slice(i, j)),
+            dask.delayed(_read_frame)(fname, slice(i, j)),
             (j - i,) + shape[1:],
             dtype
         ))

--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -11,6 +11,7 @@ dependencies:
   - pytest==3.0.5
   - dask==0.13.0
   - numpy==1.11.3
+  - scikit-image=0.12.3
   - pims==0.3.3
   - slicerator==0.9.8
   - pip:

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requirements = [
 
 test_requirements = [
     "pytest",
+    "scikit-image",
 ]
 
 cmdclasses = {

--- a/tests/test_dask_imread.py
+++ b/tests/test_dask_imread.py
@@ -4,8 +4,14 @@
 
 from __future__ import absolute_import
 
+import numbers
+
 import pytest
 
+import numpy as np
+from skimage.external import tifffile
+
+import dask.array.utils as dau
 import dask_imread
 
 
@@ -20,3 +26,61 @@ import dask_imread
 def test_errs_imread(err_type, nframes):
     with pytest.raises(err_type):
         dask_imread.imread("test.tiff", nframes=nframes)
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [
+        0,
+        1,
+    ]
+)
+@pytest.mark.parametrize(
+    "nframes, shape",
+    [
+        (1, (1, 4, 3)),
+        (3, (1, 4, 3)),
+        (1, (5, 4, 3)),
+        (2, (5, 4, 3)),
+        (1, (10, 5, 4, 3)),
+        (5, (10, 5, 4, 3)),
+        (10, (10, 5, 4, 3)),
+    ]
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.int16,
+        np.int32,
+        np.float32,
+    ]
+)
+def test_tiff_imread(tmpdir, seed, nframes, shape, dtype):
+    np.random.seed(seed)
+
+    dirpth = tmpdir.mkdir("test_imread")
+    dtype = np.dtype(dtype).type
+
+    low, high = 0.0, 1.0
+    if isinstance(dtype, numbers.Integral):
+        low, high = np.iinfo(dtype).min, np.iinfo(dtype).max
+
+    a = np.random.uniform(low=low, high=high, size=shape).astype(dtype)
+
+    fn = str(dirpth.join("test.tiff"))
+    with tifffile.TiffWriter(fn) as fh:
+        for i in range(len(a)):
+            fh.save(a[i])
+
+    d = dask_imread.imread(fn, nframes=nframes)
+
+    assert min(nframes, shape[0]) == max(d.chunks[0])
+
+    if shape[0] % nframes == 0:
+        assert nframes == d.chunks[0][-1]
+    else:
+        assert (shape[0] % nframes) == d.chunks[0][-1]
+
+    dau.assert_eq(a, d)
+
+    dirpth.remove()

--- a/tests/test_dask_imread.py
+++ b/tests/test_dask_imread.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
 from __future__ import absolute_import
 
 import pytest
 
+import dask_imread
 
-def test_import_toplevel():
-    try:
-        import dask_imread
-    except ImportError:
-        pytest.fail("Unable to import `dask_imread`.")
+
+@pytest.mark.parametrize(
+    "err_type, nframes",
+    [
+        (ValueError, 1.0),
+        (ValueError, 0),
+        (ValueError, -1),
+    ]
+)
+def test_errs_imread(err_type, nframes):
+    with pytest.raises(err_type):
+        dask_imread.imread("test.tiff", nframes=nframes)


### PR DESCRIPTION
Adds the `imread` function to handle ingestion of image files into a Dask Array. Includes some tests to make sure that this function reads in data correctly.

Note: Borrows heavily from the work on [pims_dask_exp]( https://github.com/jakirkham/pims_dask_exp ).