### PR TITLE
Require slicerator from conda and pip

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -12,3 +12,6 @@ dependencies:
   - dask==0.13.0
   - numpy==1.11.3
   - pims==0.3.3
+  - slicerator==0.9.8
+  - pip:
+    - slicerator==0.9.8

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -10,3 +10,6 @@ dependencies:
   - dask==0.13.0
   - numpy==1.11.3
   - pims==0.3.3
+  - slicerator==0.9.8
+  - pip:
+    - slicerator==0.9.8


### PR DESCRIPTION
To make sure that the versions match up between the `conda` installed `slicerator` and the `pip` installed `slicerator`. Pin the `conda` version and the `pip` version to the same version. That way even though `pip` is overwriting the `conda` installed version of the package, we can be guaranteed that the same compatibility can be expected from both.