### PR TITLE
Test another negative number of frames

### DIFF
--- a/tests/test_dask_imread.py
+++ b/tests/test_dask_imread.py
@@ -21,6 +21,7 @@ import dask_imread
         (ValueError, 1.0),
         (ValueError, 0),
         (ValueError, -1),
+        (ValueError, -2),
     ]
 )
 def test_errs_imread(err_type, nframes):


### PR DESCRIPTION
Also test -2 as an argument to `nframes` to make sure it also fails.