### PR TITLE
Support nframes equal to -1

### DIFF
--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -66,7 +66,7 @@ def imread(fname, nframes=1):
 
     if not isinstance(nframes, numbers.Integral):
         raise ValueError("`nframes` must be an integer.")
-    if not (nframes > 0):
+    if (nframes != -1) and not (nframes > 0):
         raise ValueError("`nframes` must be greater than zero.")
 
     with pims.open(fname) as imgs:

--- a/dask_imread/__init__.py
+++ b/dask_imread/__init__.py
@@ -73,6 +73,9 @@ def imread(fname, nframes=1):
         shape = (len(imgs),) + imgs.frame_shape
         dtype = numpy.dtype(imgs.pixel_type)
 
+    if nframes == -1:
+        nframes = shape[0]
+
     if nframes > shape[0]:
         warnings.warn(
             "`nframes` larger than number of frames in file."

--- a/tests/test_dask_imread.py
+++ b/tests/test_dask_imread.py
@@ -20,7 +20,6 @@ import dask_imread
     [
         (ValueError, 1.0),
         (ValueError, 0),
-        (ValueError, -1),
         (ValueError, -2),
     ]
 )

--- a/tests/test_dask_imread.py
+++ b/tests/test_dask_imread.py
@@ -39,12 +39,14 @@ def test_errs_imread(err_type, nframes):
     "nframes, shape",
     [
         (1, (1, 4, 3)),
+        (-1, (1, 4, 3)),
         (3, (1, 4, 3)),
         (1, (5, 4, 3)),
         (2, (5, 4, 3)),
         (1, (10, 5, 4, 3)),
         (5, (10, 5, 4, 3)),
         (10, (10, 5, 4, 3)),
+        (-1, (10, 5, 4, 3)),
     ]
 )
 @pytest.mark.parametrize(
@@ -73,6 +75,9 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, dtype):
             fh.save(a[i])
 
     d = dask_imread.imread(fn, nframes=nframes)
+
+    if nframes == -1:
+        nframes = shape[0]
 
     assert min(nframes, shape[0]) == max(d.chunks[0])
 


### PR DESCRIPTION
Allows `imread`'s `nframes` argument to take on the value of `-1`, which means that the whole image file should be one big chunk. This can be useful if individual image files are small and loaded separately. In these cases, the time spent doing IO is more costly than the memory used by each file.