### PR TITLE
Drop test directory removal

### DIFF
--- a/tests/test_dask_imread.py
+++ b/tests/test_dask_imread.py
@@ -87,5 +87,3 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, dtype):
         assert (shape[0] % nframes) == d.chunks[0][-1]
 
     dau.assert_eq(a, d)
-
-    dirpth.remove()


### PR DESCRIPTION
Windows seems to complain if we try to remove the test directory at the end of a test run. So simply drop the directory removal.